### PR TITLE
Add vitest tests for Game of Life

### DIFF
--- a/client/src/lib/__tests__/gameOfLife.test.ts
+++ b/client/src/lib/__tests__/gameOfLife.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { calculateNextGeneration, Cell } from '../gameOfLife'
+
+describe('Game of Life', () => {
+  it('survives with two neighbors', () => {
+    const grid: Cell[][] = [
+      [ { alive: false, color: 'white' }, { alive: true, color: 'green' }, { alive: false, color: 'white' } ],
+      [ { alive: true, color: 'blue' }, { alive: true, color: 'red' }, { alive: false, color: 'white' } ],
+      [ { alive: false, color: 'white' }, { alive: false, color: 'white' }, { alive: false, color: 'white' } ],
+    ]
+
+    const next = calculateNextGeneration(grid)
+    expect(next[1][1].alive).toBe(true)
+    expect(next[1][1].color).toBe('red')
+  })
+
+  it('survives with three neighbors', () => {
+    const grid: Cell[][] = [
+      [ { alive: true, color: 'green' }, { alive: true, color: 'blue' }, { alive: false, color: 'white' } ],
+      [ { alive: true, color: 'yellow' }, { alive: true, color: 'red' }, { alive: false, color: 'white' } ],
+      [ { alive: false, color: 'white' }, { alive: false, color: 'white' }, { alive: false, color: 'white' } ],
+    ]
+    // add third neighbor
+    grid[0][2].alive = true
+    grid[0][2].color = 'purple'
+
+    const next = calculateNextGeneration(grid)
+    expect(next[1][1].alive).toBe(true)
+    expect(next[1][1].color).toBe('red')
+  })
+
+  it('birth with exactly three neighbors inherits color', () => {
+    const grid: Cell[][] = [
+      [ { alive: false, color: 'white' }, { alive: true, color: 'red' }, { alive: false, color: 'white' } ],
+      [ { alive: true, color: 'green' }, { alive: false, color: 'white' }, { alive: true, color: 'blue' } ],
+      [ { alive: false, color: 'white' }, { alive: false, color: 'white' }, { alive: false, color: 'white' } ],
+    ]
+
+    const next = calculateNextGeneration(grid)
+    expect(next[1][1].alive).toBe(true)
+    expect(['red', 'green', 'blue']).toContain(next[1][1].color)
+    // parent colors remain
+    expect(grid[0][1].color).toBe('red')
+    expect(grid[1][0].color).toBe('green')
+    expect(grid[1][2].color).toBe('blue')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -97,7 +98,8 @@
     "tailwindcss": "^3.4.14",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
-    "vite": "^5.4.14"
+    "vite": "^5.4.14",
+    "vitest": "^1.5.1"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'client', 'src'),
+      '@shared': path.resolve(__dirname, 'shared'),
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- set up vitest with npm test script
- provide vitest configuration
- add Game of Life unit tests

## Testing
- `npm test` *(fails: vitest: not found)*