### PR TITLE
Update Vite base config for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,11 +32,9 @@ jobs:
         run: npm ci
       
       - name: Build
-        run: |
-          # Modify vite.config.ts for GitHub Pages
-          sed -i 's|base: .*|base: "/conways-game-of-life/",|' vite.config.ts
-          # Build the project
-          npm run build
+        env:
+          VITE_BASE_URL: /GameOfLifeTracker/
+        run: npm run build
       
       - name: Setup Pages
         uses: actions/configure-pages@v3

--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ Conway's Game of Life follows these simple rules:
 
 4. Open your browser and navigate to `http://localhost:5000`
 
+### Environment Variables
+
+`VITE_BASE_URL` sets the base URL used by Vite when building for production.
+For example when deploying to GitHub Pages:
+
+```bash
+VITE_BASE_URL=/GameOfLifeTracker/
+npm run build
+```
+
 ## How to Play
 
 1. **Create initial pattern**:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
     },
   },
   root: path.resolve(__dirname, "client"),
+  base: process.env.VITE_BASE_URL || "/",
   build: {
     outDir: path.resolve(__dirname, "dist/public"),
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- add `base` config to `vite.config.ts`
- configure `VITE_BASE_URL` in deploy workflow
- remove sed hack and document `VITE_BASE_URL` in README

## Testing
- `npm run check` *(fails: cannot find type definitions)*
- `npm run build` *(fails: `vite` not found)*