### PR TITLE
Update artifact path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:
-          path: './dist'
+          path: './dist/public'
 
   deploy:
     environment:


### PR DESCRIPTION
## Summary
- fix GitHub Pages upload path so it points to `dist/public`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `npm ci` *(fails: Exit handler never called)*