### PR TITLE
Clarify VITE_BASE_URL usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ Conway's Game of Life follows these simple rules:
 ### Environment Variables
 
 `VITE_BASE_URL` sets the base URL used by Vite when building for production.
-For example when deploying to GitHub Pages:
+If not specified, Vite defaults to `/`.
+When deploying to GitHub Pages, set it to your repository name. For example:
 
 ```bash
 VITE_BASE_URL=/GameOfLifeTracker/


### PR DESCRIPTION
## Summary
- clarify VITE_BASE_URL defaults in README

## Testing
- `npm ci` *(fails: connect EHOSTUNREACH)*