### PR TITLE
Improve GitHub Pages section

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,7 @@ The Game of Life has many well-known patterns you can try creating:
 
 ## Deploying to GitHub Pages
 
-The project includes a `GitHubPagesApp` that stores high scores in your browser's
-`localStorage`. To deploy this static version:
+The project includes a `GitHubPagesApp` that stores high scores in your browser's `localStorage`. To deploy this static version:
 
 1. Run the GitHub Actions workflow, or build manually with:
    ```bash


### PR DESCRIPTION
## Summary
- streamline text in the **Deploying to GitHub Pages** instructions
- ensure README ends with a newline

## Testing
- `npm test` *(fails: vitest not found)*