### PR TITLE
Update stabilization threshold

### DIFF
--- a/client/src/components/GameGrid.tsx
+++ b/client/src/components/GameGrid.tsx
@@ -204,7 +204,7 @@ export default function GameGrid({
       }
       
       // End condition 2: Pattern has stabilized (handled via stableGenerations)
-      if (stableGenerations > 10) {
+      if (stableGenerations >= 10) {
         handleGameOver('Game over! Pattern has stabilized for 10 generations.');
         return;
       }


### PR DESCRIPTION
## Summary
- trigger game loop stabilization condition at 10 generations rather than after

## Testing
- `npm test` *(fails: vitest not found)*