### PR TITLE
Fix typo in comment

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -55,7 +55,7 @@ export async function setupVite(app: Express, server: Server) {
         "index.html",
       );
 
-      // always reload the index.html file from disk incase it changes
+      // always reload the index.html file from disk in case it changes
       let template = await fs.promises.readFile(clientTemplate, "utf-8");
       template = template.replace(
         `src="/src/main.tsx"`,


### PR DESCRIPTION
## Summary
- fix a typo in `server/vite.ts` comment

## Testing
- `npm test` *(fails: vitest not found)*