### PR TITLE
Add tests and inject storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ The Game of Life has many well-known patterns you can try creating:
 - **Styling**: Tailwind CSS
 - **Data Storage**: In-memory storage
 
+## Testing
+
+Run all unit tests with:
+
+```bash
+npm test
+```
+
 ## Deploying to GitHub Pages
 
 The project includes a `GitHubPagesApp` that stores high scores in your browser's `localStorage`. To deploy this static version:

--- a/client/src/components/__tests__/GameControls.test.tsx
+++ b/client/src/components/__tests__/GameControls.test.tsx
@@ -1,0 +1,58 @@
+/* vitest-environment jsdom */
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import GameControls from '../GameControls';
+
+describe('GameControls', () => {
+  it('calls setGameRunning on Start and Pause', () => {
+    const startSpy = vi.fn();
+    const pauseSpy = vi.fn();
+    let running = false;
+    const setRunning = (val: boolean) => {
+      running = val;
+      if (val) startSpy(); else pauseSpy();
+    };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    act(() => {
+      createRoot(container).render(
+        <GameControls
+          gameRunning={running}
+          setGameRunning={setRunning}
+          speed={1}
+          setSpeed={() => {}}
+        />
+      );
+    });
+    const [startBtn, pauseBtn] = container.querySelectorAll('button');
+    act(() => { startBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(startSpy).toHaveBeenCalled();
+    act(() => { pauseBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(pauseSpy).toHaveBeenCalled();
+  });
+
+  it('updates speed via slider', () => {
+    const speedSpy = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    act(() => {
+      createRoot(container).render(
+        <GameControls
+          gameRunning={false}
+          setGameRunning={() => {}}
+          speed={5}
+          setSpeed={speedSpy}
+        />
+      );
+    });
+    const slider = container.querySelector('input[type="range"]') as HTMLInputElement;
+    act(() => {
+      slider.value = '8';
+      slider.dispatchEvent(new Event('input', { bubbles: true }));
+      slider.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    expect(speedSpy).toHaveBeenCalledWith(8);
+  });
+});

--- a/client/src/components/__tests__/GameGrid.test.tsx
+++ b/client/src/components/__tests__/GameGrid.test.tsx
@@ -1,0 +1,35 @@
+/* vitest-environment jsdom */
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import GameGrid from '../GameGrid';
+
+function renderGrid(gridSize: number) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  act(() => {
+    createRoot(container).render(
+      <GameGrid
+        gridSize={gridSize}
+        setGridSize={() => {}}
+        gameRunning={false}
+        setGameRunning={() => {}}
+        speed={1}
+        setGeneration={() => {}}
+        setLivingCells={() => {}}
+        setDensity={() => {}}
+        setLongestPattern={() => {}}
+      />
+    );
+  });
+  return container;
+}
+
+describe('GameGrid', () => {
+  it('renders correct number of cells', () => {
+    const container = renderGrid(3);
+    const cells = container.querySelectorAll('.cell');
+    expect(cells.length).toBe(9);
+  });
+});

--- a/client/src/components/__tests__/HighScores.test.tsx
+++ b/client/src/components/__tests__/HighScores.test.tsx
@@ -1,0 +1,49 @@
+/* vitest-environment jsdom */
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import HighScores from '../HighScores';
+
+function renderComponent(props: any) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  act(() => {
+    createRoot(container).render(<HighScores {...props} />);
+  });
+  return container;
+}
+
+describe('HighScores', () => {
+  it('shows skeletons when loading', () => {
+    const container = renderComponent({
+      currentSessionActive: true,
+      currentMaxGen: 0,
+      currentMaxPop: 0,
+      currentLongest: 0,
+      isLoading: true,
+      sessionId: 's1'
+    });
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+  });
+
+  it('displays best scores', () => {
+    const scores = {
+      maxGenerations: { sessionId: 's1', maxGenerations: 10, maxPopulation: 5, longestPattern: 3, gridSize: 25, date: new Date().toISOString(), id: 1 },
+      maxPopulation: { sessionId: 's2', maxGenerations: 8, maxPopulation: 20, longestPattern: 2, gridSize: 25, date: new Date().toISOString(), id: 2 },
+      longestPattern: { sessionId: 's3', maxGenerations: 5, maxPopulation: 5, longestPattern: 15, gridSize: 25, date: new Date().toISOString(), id: 3 }
+    };
+    const container = renderComponent({
+      currentSessionActive: false,
+      currentMaxGen: 1,
+      currentMaxPop: 2,
+      currentLongest: 3,
+      allTimeBestScores: scores,
+      isLoading: false,
+      sessionId: 'x'
+    });
+    expect(container.textContent).toContain('10');
+    expect(container.textContent).toContain('20');
+    expect(container.textContent).toContain('15 gens');
+  });
+});

--- a/server/__tests__/routes.test.ts
+++ b/server/__tests__/routes.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import express from 'express';
+import { registerRoutes } from '../routes';
+import { MemStorage } from '../storage';
+import type { Server } from 'http';
+
+let server: Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  server = await registerRoutes(app, new MemStorage());
+  await new Promise<void>(resolve => server.listen(0, resolve));
+  const addr = server.address();
+  if (addr && typeof addr === 'object') {
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+  } else {
+    throw new Error('failed to start server');
+  }
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe('high score routes', () => {
+  it('creates and retrieves a high score', async () => {
+    const body = {
+      sessionId: 'test',
+      maxGenerations: 5,
+      maxPopulation: 5,
+      longestPattern: 2,
+      gridSize: 25,
+      date: new Date().toISOString()
+    };
+    const postRes = await fetch(`${baseUrl}/api/high-scores`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+    expect(postRes.status).toBe(201);
+    const created = await postRes.json();
+    const getRes = await fetch(`${baseUrl}/api/high-scores/test`);
+    expect(getRes.status).toBe(200);
+    const fetched = await getRes.json();
+    expect(fetched.id).toBe(created.id);
+  });
+
+  it('returns all-time best scores', async () => {
+    const res = await fetch(`${baseUrl}/api/high-scores/best/all-time`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toHaveProperty('maxGenerations');
+  });
+});

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,16 +1,16 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
-import { storage } from "./storage";
+import { storage, type IStorage } from "./storage";
 import { insertHighScoreSchema, updateHighScoreSchema } from "@shared/schema";
 import { z } from "zod";
 
-export async function registerRoutes(app: Express): Promise<Server> {
+export async function registerRoutes(app: Express, store: IStorage = storage): Promise<Server> {
   // High Scores API Routes
   
   // Get all high scores
   app.get("/api/high-scores", async (_req, res) => {
     try {
-      const highScores = await storage.getAllHighScores();
+      const highScores = await store.getAllHighScores();
       res.json(highScores);
     } catch (error) {
       console.error("Error fetching high scores:", error);
@@ -41,7 +41,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       };
       
       const validatedData = insertHighScoreSchema.parse(highScoreData);
-      const newHighScore = await storage.createHighScore(validatedData);
+      const newHighScore = await store.createHighScore(validatedData);
       res.status(201).json(newHighScore);
     } catch (error) {
       if (error instanceof z.ZodError) {
@@ -66,7 +66,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       const validatedData = updateHighScoreSchema.parse(updateData);
       
-      const updatedHighScore = await storage.updateHighScoreBySessionId(sessionId, validatedData);
+      const updatedHighScore = await store.updateHighScoreBySessionId(sessionId, validatedData);
       
       if (!updatedHighScore) {
         return res.status(404).json({ message: "High score not found" });
@@ -86,7 +86,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Get the all time best high scores (must be defined before the dynamic :sessionId route)
   app.get("/api/high-scores/best/all-time", async (_req, res) => {
     try {
-      const bestScores = await storage.getAllTimeBestScores();
+      const bestScores = await store.getAllTimeBestScores();
       res.json(bestScores);
     } catch (error) {
       console.error("Error fetching best scores:", error);
@@ -98,7 +98,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.get("/api/high-scores/:sessionId", async (req, res) => {
     try {
       const { sessionId } = req.params;
-      const highScore = await storage.getHighScoreBySessionId(sessionId);
+      const highScore = await store.getHighScoreBySessionId(sessionId);
       
       if (!highScore) {
         return res.status(404).json({ message: "High score not found" });


### PR DESCRIPTION
## Summary
- inject storage dependency into Express routes
- document running unit tests
- add basic React component tests for GameGrid, GameControls and HighScores
- add API route tests using an in-memory server

## Testing
- `npm test --silent` *(fails: vitest not found)*