### PR TITLE
Adjust wouter base path

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,23 +1,25 @@
-import { Switch, Route } from "wouter";
+import { Switch, Route, Router as WouterRouter } from "wouter";
 import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import NotFound from "@/pages/not-found";
 import Home from "@/pages/home";
 
-function Router() {
+function AppRouter() {
   return (
-    <Switch>
-      <Route path="/" component={Home} />
-      <Route component={NotFound} />
-    </Switch>
+    <WouterRouter base={import.meta.env.BASE_URL}>
+      <Switch>
+        <Route path="/" component={Home} />
+        <Route component={NotFound} />
+      </Switch>
+    </WouterRouter>
   );
 }
 
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <Router />
+      <AppRouter />
       <Toaster />
     </QueryClientProvider>
   );

--- a/client/src/GitHubPagesApp.tsx
+++ b/client/src/GitHubPagesApp.tsx
@@ -1,4 +1,4 @@
-import { Switch, Route } from "wouter";
+import { Switch, Route, Router as WouterRouter } from "wouter";
 import { useState, useEffect } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "./lib/queryClient";
@@ -9,10 +9,12 @@ import NotFound from "./pages/not-found";
 function AppContent() {
   return (
     <main className="flex flex-col min-h-screen bg-background">
-      <Switch>
-        <Route path="/" component={StaticHome} />
-        <Route component={NotFound} />
-      </Switch>
+      <WouterRouter base={import.meta.env.BASE_URL}>
+        <Switch>
+          <Route path="/" component={StaticHome} />
+          <Route component={NotFound} />
+        </Switch>
+      </WouterRouter>
       <Toaster />
     </main>
   );


### PR DESCRIPTION
## Summary
- use `WouterRouter` alias to respect Vite's `BASE_URL`
- wrap both routers so deployed builds work from subpaths

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*