### PR TITLE
Add Drizzle ORM storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ VITE_BASE_URL=/GameOfLifeTracker/
 npm run build
 ```
 
+### Database Setup
+
+Set a `DATABASE_URL` environment variable pointing to your PostgreSQL instance.
+Run the migrations with:
+
+```bash
+npm run db:push
+```
+
+When `DATABASE_URL` is provided, the server will use the database for persisting high scores.
+
 ## How to Play
 
 1. **Create initial pattern**:
@@ -142,7 +153,7 @@ The Game of Life has many well-known patterns you can try creating:
 - **Backend**: Express.js, TypeScript
 - **State Management**: TanStack Query
 - **Styling**: Tailwind CSS
-- **Data Storage**: In-memory storage
+- **Data Storage**: In-memory or PostgreSQL storage via Drizzle ORM
 
 ## Deploying to GitHub Pages
 

--- a/migrations/0000_init.sql
+++ b/migrations/0000_init.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS "users" (
+    "id" serial PRIMARY KEY,
+    "username" text NOT NULL UNIQUE,
+    "password" text NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "high_scores" (
+    "id" serial PRIMARY KEY,
+    "max_generations" integer NOT NULL,
+    "max_population" integer NOT NULL,
+    "longest_pattern" integer NOT NULL,
+    "grid_size" integer NOT NULL,
+    "date" timestamp NOT NULL,
+    "session_id" text NOT NULL
+);
+
+

--- a/server/__tests__/highScore.test.ts
+++ b/server/__tests__/highScore.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { MemStorage, type IStorage } from '../storage';
+
+let storage: IStorage;
+
+beforeEach(() => {
+  storage = new MemStorage();
+});
+
+describe('high score CRUD', () => {
+  it('creates and fetches a high score', async () => {
+    const created = await storage.createHighScore({
+      sessionId: 'abc',
+      maxGenerations: 10,
+      maxPopulation: 20,
+      longestPattern: 5,
+      gridSize: 25,
+      date: new Date(),
+    });
+
+    const fetched = await storage.getHighScoreBySessionId('abc');
+    expect(fetched).toEqual(created);
+  });
+
+  it('updates a high score', async () => {
+    await storage.createHighScore({
+      sessionId: 'abc',
+      maxGenerations: 10,
+      maxPopulation: 20,
+      longestPattern: 5,
+      gridSize: 25,
+      date: new Date(),
+    });
+
+    const updated = await storage.updateHighScoreBySessionId('abc', {
+      maxGenerations: 50,
+    });
+
+    expect(updated?.maxGenerations).toBe(50);
+  });
+
+  it('returns all-time best scores', async () => {
+    await storage.createHighScore({
+      sessionId: 'a',
+      maxGenerations: 1,
+      maxPopulation: 2,
+      longestPattern: 3,
+      gridSize: 25,
+      date: new Date(),
+    });
+    await storage.createHighScore({
+      sessionId: 'b',
+      maxGenerations: 5,
+      maxPopulation: 1,
+      longestPattern: 4,
+      gridSize: 25,
+      date: new Date(),
+    });
+
+    const best = await storage.getAllTimeBestScores();
+    expect(best.maxGenerations?.maxGenerations).toBe(5);
+    expect(best.longestPattern?.longestPattern).toBe(4);
+  });
+});
+

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,8 +1,19 @@
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
+import { DatabaseStorage, setStorage } from "./storage";
 
 const app = express();
+
+if (process.env.DATABASE_URL) {
+  try {
+    setStorage(new DatabaseStorage(process.env.DATABASE_URL));
+    log("using database storage", "storage");
+  } catch (err) {
+    log(`failed to connect to database: ${String(err)}`, "storage");
+  }
+}
+
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,4 +1,15 @@
-import { users, type User, type InsertUser, type HighScore, type InsertHighScore, type UpdateHighScore } from "@shared/schema";
+import {
+  users,
+  highScores,
+  type User,
+  type InsertUser,
+  type HighScore,
+  type InsertHighScore,
+  type UpdateHighScore,
+} from "@shared/schema";
+import { drizzle } from "drizzle-orm/neon-http";
+import { neon } from "@neondatabase/serverless";
+import { eq, desc, gt } from "drizzle-orm";
 
 // modify the interface with any CRUD methods
 // you might need
@@ -138,4 +149,105 @@ export class MemStorage implements IStorage {
   }
 }
 
-export const storage = new MemStorage();
+export class DatabaseStorage implements IStorage {
+  private db;
+
+  constructor(url: string) {
+    const client = neon(url);
+    this.db = drizzle(client);
+  }
+
+  async getUser(id: number): Promise<User | undefined> {
+    const rows = await this.db.select().from(users).where(eq(users.id, id));
+    return rows[0];
+  }
+
+  async getUserByUsername(username: string): Promise<User | undefined> {
+    const rows = await this.db
+      .select()
+      .from(users)
+      .where(eq(users.username, username));
+    return rows[0];
+  }
+
+  async createUser(user: InsertUser): Promise<User> {
+    const rows = await this.db.insert(users).values(user).returning();
+    return rows[0];
+  }
+
+  async getAllHighScores(): Promise<HighScore[]> {
+    const rows = await this.db.select().from(highScores);
+    return rows.map((r) => ({ ...r, date: r.date.toISOString() }));
+  }
+
+  async getHighScoreBySessionId(sessionId: string): Promise<HighScore | undefined> {
+    const rows = await this.db
+      .select()
+      .from(highScores)
+      .where(eq(highScores.sessionId, sessionId));
+    const row = rows[0];
+    return row ? { ...row, date: row.date.toISOString() } : undefined;
+  }
+
+  async createHighScore(highScore: InsertHighScore & { date: Date }): Promise<HighScore> {
+    const rows = await this.db.insert(highScores).values(highScore).returning();
+    const row = rows[0];
+    return { ...row, date: row.date.toISOString() };
+  }
+
+  async updateHighScoreBySessionId(
+    sessionId: string,
+    data: UpdateHighScore,
+  ): Promise<HighScore | undefined> {
+    const rows = await this.db
+      .update(highScores)
+      .set(data)
+      .where(eq(highScores.sessionId, sessionId))
+      .returning();
+    const row = rows[0];
+    return row ? { ...row, date: row.date.toISOString() } : undefined;
+  }
+
+  async getAllTimeBestScores(): Promise<{
+    maxGenerations: HighScore | null;
+    maxPopulation: HighScore | null;
+    longestPattern: HighScore | null;
+  }> {
+    const [maxGen] = await this.db
+      .select()
+      .from(highScores)
+      .where(gt(highScores.maxGenerations, 0))
+      .orderBy(desc(highScores.maxGenerations))
+      .limit(1);
+
+    const [maxPop] = await this.db
+      .select()
+      .from(highScores)
+      .where(gt(highScores.maxPopulation, 0))
+      .orderBy(desc(highScores.maxPopulation))
+      .limit(1);
+
+    const [longest] = await this.db
+      .select()
+      .from(highScores)
+      .where(gt(highScores.longestPattern, 0))
+      .orderBy(desc(highScores.longestPattern))
+      .limit(1);
+
+    const toHS = (row: any): HighScore => ({ ...row, date: row.date.toISOString() });
+
+    return {
+      maxGenerations: maxGen ? toHS(maxGen) : null,
+      maxPopulation: maxPop ? toHS(maxPop) : null,
+      longestPattern: longest ? toHS(longest) : null,
+    };
+  }
+}
+
+export let storage: IStorage = new MemStorage();
+
+export function setStorage(newStorage: IStorage) {
+  storage = newStorage;
+}
+
+


### PR DESCRIPTION
## Summary
- implement `DatabaseStorage` using Drizzle ORM
- switch to database storage when `DATABASE_URL` is present
- create initial migration script
- document database setup and update feature list
- add unit tests for high score CRUD operations

## Testing
- `npm test` *(fails: request to https://registry.npmjs.org/vitest failed, reason: connect EHOSTUNREACH)*