### PR TITLE
Add webcam overlay page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,12 +4,14 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import NotFound from "@/pages/not-found";
 import Home from "@/pages/home";
+import WebcamOverlay from "@/pages/WebcamOverlay";
 
 function AppRouter() {
   return (
     <WouterRouter base={import.meta.env.BASE_URL}>
       <Switch>
         <Route path="/" component={Home} />
+        <Route path="/overlay" component={WebcamOverlay} />
         <Route component={NotFound} />
       </Switch>
     </WouterRouter>

--- a/client/src/GitHubPagesApp.tsx
+++ b/client/src/GitHubPagesApp.tsx
@@ -5,6 +5,7 @@ import { queryClient } from "./lib/queryClient";
 import { Toaster } from "@/components/ui/toaster";
 import StaticHome from "./pages/StaticHome";
 import NotFound from "./pages/not-found";
+import WebcamOverlay from "./pages/WebcamOverlay";
 
 function AppContent() {
   return (
@@ -12,6 +13,7 @@ function AppContent() {
       <WouterRouter base={import.meta.env.BASE_URL}>
         <Switch>
           <Route path="/" component={StaticHome} />
+          <Route path="/overlay" component={WebcamOverlay} />
           <Route component={NotFound} />
         </Switch>
       </WouterRouter>

--- a/client/src/lib/gameOfLife.ts
+++ b/client/src/lib/gameOfLife.ts
@@ -10,8 +10,26 @@ export function getRandomColor(): string {
   const hue = Math.floor(Math.random() * 360); // 0-359 degrees on the color wheel
   const saturation = 70 + Math.floor(Math.random() * 30); // 70-100% saturation for vibrant colors
   const lightness = 40 + Math.floor(Math.random() * 20); // 40-60% lightness for balanced brightness
-  
+
   return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+}
+
+// Rotate an HSL color by the given number of degrees
+export function rotateHue(color: string, degrees: number): string {
+  const match = color.match(/hsl\((\d+),\s*(\d+)%,\s*(\d+)%\)/);
+  if (!match) return color;
+  let hue = (parseInt(match[1]) + degrees) % 360;
+  if (hue < 0) hue += 360;
+  const saturation = match[2];
+  const lightness = match[3];
+  return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+}
+
+// Rotate all cell colors in a grid
+export function rotateGridColors(grid: Cell[][], degrees: number): Cell[][] {
+  return grid.map((row) =>
+    row.map((cell) => ({ ...cell, color: rotateHue(cell.color, degrees) }))
+  );
 }
 
 // Create an empty grid of specified size

--- a/client/src/pages/WebcamOverlay.tsx
+++ b/client/src/pages/WebcamOverlay.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  Cell,
+  createEmptyGrid,
+  calculateNextGeneration,
+  rotateGridColors,
+  getRandomColor,
+} from "@/lib/gameOfLife";
+
+// Simple grid size. Larger values give finer detail
+const GRID_SIZE = 50;
+const COLOR_ROTATION_DEG = 2;
+
+export default function WebcamOverlay() {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const gridRef = useRef<Cell[][]>(createEmptyGrid(GRID_SIZE));
+  const [ready, setReady] = useState(false);
+
+  // Start webcam
+  useEffect(() => {
+    async function startCam() {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+          await videoRef.current.play();
+          setReady(true);
+        }
+      } catch (e) {
+        console.error("Error accessing webcam", e);
+      }
+    }
+    startCam();
+  }, []);
+
+  // Load face detection library lazily
+  const faceApiRef = useRef<any>(null);
+  useEffect(() => {
+    async function load() {
+      try {
+        const m = await import("@vladmandic/face-api");
+        await m.nets.tinyFaceDetector.loadFromUri("/models");
+        faceApiRef.current = m;
+      } catch (e) {
+        console.error("Failed to load face-api", e);
+      }
+    }
+    load();
+    return () => {};
+  }, []);
+
+  // Main animation loop
+  useEffect(() => {
+    if (!ready) return;
+    const canvas = canvasRef.current!;
+    const ctx = canvas.getContext("2d")!;
+    const cellSize = canvas.width / GRID_SIZE;
+
+    async function tick() {
+      if (videoRef.current && faceApiRef.current) {
+        const detections = await faceApiRef.current.detectAllFaces(
+          videoRef.current,
+          new faceApiRef.current.TinyFaceDetectorOptions()
+        );
+        detections.forEach((det: any) => {
+          const { x, y, width, height } = det.box;
+          const startRow = Math.floor(y / cellSize);
+          const endRow = Math.floor((y + height) / cellSize);
+          const startCol = Math.floor(x / cellSize);
+          const endCol = Math.floor((x + width) / cellSize);
+          for (let r = startRow; r <= endRow; r++) {
+            if (r < 0 || r >= GRID_SIZE) continue;
+            if (startCol >= 0 && startCol < GRID_SIZE) {
+              gridRef.current[r][startCol] = { alive: true, color: getRandomColor() };
+            }
+            if (endCol >= 0 && endCol < GRID_SIZE) {
+              gridRef.current[r][endCol] = { alive: true, color: getRandomColor() };
+            }
+          }
+          for (let c = startCol; c <= endCol; c++) {
+            if (c < 0 || c >= GRID_SIZE) continue;
+            if (startRow >= 0 && startRow < GRID_SIZE) {
+              gridRef.current[startRow][c] = { alive: true, color: getRandomColor() };
+            }
+            if (endRow >= 0 && endRow < GRID_SIZE) {
+              gridRef.current[endRow][c] = { alive: true, color: getRandomColor() };
+            }
+          }
+        });
+      }
+
+      // Game of Life step and color rotation
+      gridRef.current = calculateNextGeneration(gridRef.current);
+      gridRef.current = rotateGridColors(gridRef.current, COLOR_ROTATION_DEG);
+
+      // Draw
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      for (let i = 0; i < GRID_SIZE; i++) {
+        for (let j = 0; j < GRID_SIZE; j++) {
+          const cell = gridRef.current[i][j];
+          if (cell.alive) {
+            ctx.fillStyle = cell.color;
+            ctx.fillRect(j * cellSize, i * cellSize, cellSize, cellSize);
+          }
+        }
+      }
+
+      requestAnimationFrame(tick);
+    }
+
+    const id = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(id);
+  }, [ready]);
+
+  return (
+    <div className="flex items-center justify-center w-full h-screen bg-black relative">
+      <video ref={videoRef} className="absolute w-full h-full object-cover" muted />
+      <canvas ref={canvasRef} width={640} height={480} className="absolute" />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add new `WebcamOverlay` page that uses the webcam and face detection
- allow color rotation by adding hue rotation helpers
- route `/overlay` to the new page in the main app and GitHub Pages app

## Testing
- `npm test` *(fails: vitest not found)*